### PR TITLE
COMP: Cast QFlags to int for QString::arg() compatibility with Qt 6.11

### DIFF
--- a/pqAbstractItemViewEventTranslator.cxx
+++ b/pqAbstractItemViewEventTranslator.cxx
@@ -89,9 +89,9 @@ bool pqAbstractItemViewEventTranslator::translateEvent(QObject* Object, QEvent* 
       }
 
       QString info = QString("%1,%2,%3,%4,%5,%6")
-                       .arg(mouseEvent->button())
-                       .arg(mouseEvent->buttons())
-                       .arg(mouseEvent->modifiers())
+                       .arg(int(mouseEvent->button()))
+                       .arg(int(mouseEvent->buttons()))
+                       .arg(int(mouseEvent->modifiers()))
                        .arg(relPt.x())
                        .arg(relPt.y())
                        .arg(idxStr);

--- a/pqBasicWidgetEventTranslator.cxx
+++ b/pqBasicWidgetEventTranslator.cxx
@@ -52,9 +52,9 @@ bool pqBasicWidgetEventTranslator::translateEvent(
         auto pos = mouseEvent->position().toPoint();
 #endif
         QString info = QString("%1,%2,%3,%4,%5")
-                         .arg(mouseEvent->button())
-                         .arg(mouseEvent->buttons())
-                         .arg(mouseEvent->modifiers())
+                         .arg(int(mouseEvent->button()))
+                         .arg(int(mouseEvent->buttons()))
+                         .arg(int(mouseEvent->modifiers()))
                          .arg(pos.x())
                          .arg(pos.y());
 


### PR DESCRIPTION
Qt 6.11 removed the implicit QFlags-to-int conversion used by QString::arg().
Cast mouseEvent->button(), ->buttons(), and ->modifiers() to int() explicitly
in the two translators that passed them directly to .arg() without a local
int variable.
